### PR TITLE
don't build loc_api without QCPATH

### DIFF
--- a/loc_api/ds_api/Android.mk
+++ b/loc_api/ds_api/Android.mk
@@ -1,3 +1,4 @@
+ifneq ($(QCPATH),)
 ifneq ($(BUILD_TINY_ANDROID),true)
 
 LOCAL_PATH := $(call my-dir)
@@ -47,3 +48,4 @@ LOCAL_PRELINK_MODULE := false
 include $(BUILD_SHARED_LIBRARY)
 
 endif # not BUILD_TINY_ANDROID
+endif #QCPATH

--- a/loc_api/loc_api_v02/Android.mk
+++ b/loc_api/loc_api_v02/Android.mk
@@ -1,3 +1,4 @@
+ifneq ($(QCPATH),)
 ifneq ($(BUILD_TINY_ANDROID),true)
 
 LOCAL_PATH := $(call my-dir)
@@ -60,3 +61,4 @@ LOCAL_PRELINK_MODULE := false
 include $(BUILD_SHARED_LIBRARY)
 
 endif # not BUILD_TINY_ANDROID
+endif #QCPATH


### PR DESCRIPTION
loc_api depends on libqmi_cci which is
proprietary.

Fixes Build for Nexus5X